### PR TITLE
COMP: add dependency for application singletons

### DIFF
--- a/DataStore/Logic/CMakeLists.txt
+++ b/DataStore/Logic/CMakeLists.txt
@@ -15,6 +15,7 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
+  qSlicerBaseQTGUI
  )
 #-----------------------------------------------------------------------------
 SlicerMacroBuildModuleLogic(


### PR DESCRIPTION
Because the DataStore logic relies on qSlicerApplication::application()
it needs to explicitly link to the library or the symbol may not be resolved
(happens for example on debian 9 with gcc 6).

If this code were to be refactored it would be good to avoid a gui dependency
in the logic code.  For example, here the application's layout manager is used to take
a screenshot, but there could be a generic non-GUI class with a no-op method
for the screenshot, while the gui code could provide a concrete subclass that implements
the screenshot method and sets that as an attribute of the logic.