### PR TITLE
COMP: Fix "inconsistent-missing-override" warnings

### DIFF
--- a/DataStore/Logic/vtkSlicerDataStoreLogic.h
+++ b/DataStore/Logic/vtkSlicerDataStoreLogic.h
@@ -48,7 +48,7 @@ public:
 
   static vtkSlicerDataStoreLogic *New();
   vtkTypeMacro(vtkSlicerDataStoreLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
   
   // Load a MRML File.
   void LoadMRMLScene(QString mrmlFilePath);
@@ -60,13 +60,13 @@ protected:
   vtkSlicerDataStoreLogic();
   virtual ~vtkSlicerDataStoreLogic();
 
-  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene);
+  virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene) VTK_OVERRIDE;
   
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void RegisterNodes() VTK_OVERRIDE;
+  virtual void UpdateFromMRMLScene() VTK_OVERRIDE;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) VTK_OVERRIDE;
 private:
 
   vtkSlicerDataStoreLogic(const vtkSlicerDataStoreLogic&); // Not implemented


### PR DESCRIPTION
This commit adds the VTK_OVERRIDE macros to fix warnings like the one
reported below occurring when building OpenIGTLink against VTK 8:

```
In file included from /path/to/Slicer-build/Slicer-build/Modules/Remote/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPointsPython.cxx:12:
In file included from /path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPoints.h:19:
/path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLBase.h:58:8: warning: 'PrintSelf' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void PrintSelf(ostream& os, vtkIndent indent);
       ^
/path/to/Slicer-build/VTKv8/Common/Core/vtkObject.h:115:8: note: overridden virtual function is here
  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
       ^
```